### PR TITLE
support exponents in Currency conversion

### DIFF
--- a/Currency.py
+++ b/Currency.py
@@ -38,6 +38,8 @@ class Currency():
         elif len(segments) == 2:
             [l, r] = segments
             if len(r) <= 9:
+                if 'e' in r:
+                    r = str(float(r)).split('.')[1] # round down exponent fractions
                 return int(l + r + ('0' * (9 - len(r))))
             else:
                 raise Exception('invalid coda currency format: %s' % s)


### PR DESCRIPTION
tried running this with epoch 7:
```
✦ ❯ python3 payout.py
Using ledger hash: jxQgtuyHp8nA2P6F9CSRrLcVeHi8Ap7wVHeNnH2UbSX15izcSHK
This script will payout from blocks 0 to 35771 in epoch 7
The pool total staking balance is: 15889904.84812511
The Foundation delegation balance is: 3742265.809579806
There are 701 delegates in the pool
We won these 2 blocks:
+-------------+------------------------+--------------+------------------------+---------------------+------------------------+
| BlockHeight | Supercharged Weighting |   Coinbase   | Producer Fee Transfers | Snark Fee Transfers | Coinbase Fee Transfers |
+-------------+------------------------+--------------+------------------------+---------------------+------------------------+
|    35751    |   1.9999388926232287   | 720000000000 |        44000000        |          0          |           0            |
|    35666    |   1.9999583350693722   | 720000000000 |        30000000        |          0          |           0            |
+-------------+------------------------+--------------+------------------------+---------------------+------------------------+
We are paying out 1440074000000 nanomina in this window.
That is 1440.074000000 mina
Our fee is 72.003700000 mina
Traceback (most recent call last):
  File "/Users/omrieival/projects/mina-payout-script/payout.py", line 386, in <module>
    Currency.Currency(
  File "/Users/omrieival/projects/mina-payout-script/Currency.py", line 62, in __init__
    self.__nanocodas = Currency.__nanocodas_from_string(str(value))
  File "/Users/omrieival/projects/mina-payout-script/Currency.py", line 41, in __nanocodas_from_string
    return int(float(l) + float(r) + ('0' * (9 - len(r))))
TypeError: unsupported operand type(s) for +: 'float' and 'str'
```